### PR TITLE
separate field to read-only, write-required 

### DIFF
--- a/checkins/serializer.py
+++ b/checkins/serializer.py
@@ -21,7 +21,7 @@ class SessionHistorySerializer(serializers.ModelSerializer):
 class SessionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Session
-        fields = '__all__'
+        fields = ['imageUrl','name','description','location','member_id','launch_date','max_attendee','application_fee']
 
 
 class SessionInfoSerializer(serializers.ModelSerializer):
@@ -30,7 +30,7 @@ class SessionInfoSerializer(serializers.ModelSerializer):
         source='attendee.count', 
         read_only=True
     )
-    attendee = SessionHistorySerializer(many = True)
+    attendee = SessionHistorySerializer(many = True, read_only = True)
     class Meta:
         model = Session
         fields = '__all__'


### PR DESCRIPTION
[backend]
-
- `/api/v1/session` POST 에서 실제 필요한 내용만 입력받도록 열거형으로 변경
- `/api/v1/session` GET시에 제공하는 데이터에 read only 영역 명시
  - serializer에서 read only 로 제공해야 하는 내용들이 required로 들어가면서 post불가 사태 발생(..)